### PR TITLE
Attempt to fix numpy.pop error

### DIFF
--- a/extracttab.py
+++ b/extracttab.py
@@ -267,16 +267,16 @@ def process_page(pgs) :
 
   while i < len(vd) :
     if vd[i+1]-vd[i] > maxdiv :
-      vd.pop(i)
-      vd.pop(i)
+      vd = delete(vd,i)
+      vd = delete(vd,i)
     else:
       i=i+2
   
   j = 0 
   while j < len(hd):
     if hd[j+1]-hd[j] > maxdiv :
-      hd.pop(j)
-      hd.pop(j)
+      hd = delete(hd,j)
+      hd = delete(hd,j)
     else:
       j=j+2
   


### PR DESCRIPTION
Numpy has no 'pop' support, but does support 'delete'.
Re-wrote the section of code that calls pop with delete
and returns the new array back to overwrite the old array.

(It may be more efficient to convert the array to a python list,
and work on that list. I don't see anything after the 'pop's that
needs a numpy array).
