### PR TITLE
Fix/table csv

### DIFF
--- a/extracttab.py
+++ b/extracttab.py
@@ -430,8 +430,7 @@ def o_table_csv(cells,pgs) :
 
   for (i,j,u,v,pg,value) in cells :
       r=[i,j,pg]
-      for ii, (l_it, r_it) in enumerate(zip(l, r)):
-          l[ii] = max(l_it, r_it)
+      l = [max(x) for x in zip(l,r)]
   
   tab = [ [ [ "" for x in range(l[0]+1)
             ] for x in range(l[1]+1)

--- a/extracttab.py
+++ b/extracttab.py
@@ -482,6 +482,7 @@ def o_table_html(cells,pgs) :
 #-----------------------------------------------------------------------
 # main
 
+args = procargs()
 
 cells = []
 for pgs in args.page :

--- a/extracttab.py
+++ b/extracttab.py
@@ -427,9 +427,11 @@ def o_cells_xml(cells,pgs) :
   
 def o_table_csv(cells,pgs) :
   l=[0,0,0]
+
   for (i,j,u,v,pg,value) in cells :
       r=[i,j,pg]
-      l = (l>=r)*l+(l<r)*r
+      for ii, (l_it, r_it) in enumerate(zip(l, r)):
+          l[ii] = max(l_it, r_it)
   
   tab = [ [ [ "" for x in range(l[0]+1)
             ] for x in range(l[1]+1)
@@ -480,7 +482,6 @@ def o_table_html(cells,pgs) :
 #-----------------------------------------------------------------------
 # main
 
-args = procargs()
 
 cells = []
 for pgs in args.page :


### PR DESCRIPTION
When extracting to csv I encountered following exception.

`Traceback (most recent call last):
  File "extracttab.py", line 492, in <module>
    } [ args.t ](cells,args.page)
  File "extracttab.py", line 439, in o_table_csv
    tab[pg][j][i] = value
IndexError: list index out of range`

 I have no idea what was wrong inside method, but somehow contents of `l` got errorneously calculated. I fixed that.
