### PR TITLE
simplifying setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages
-import sys, os
-from pip.req import parse_requirements
+import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
@@ -8,10 +7,6 @@ README = open(os.path.join(here, 'README.md')).read()
 
 
 version = '0.1'
-
-from_requirements_txt = parse_requirements("requirements.txt")
-install_requires = [    str(ir.req) for ir in from_requirements_txt ]
-
 
 setup(name='pdf-table-extract',
     version=version,
@@ -28,7 +23,7 @@ setup(name='pdf-table-extract',
     packages=find_packages('src'),
     package_dir = {'': 'src'},include_package_data=True,
     zip_safe=False,
-    install_requires=install_requires,
+    install_requires=['numpy'],
     entry_points={
         'console_scripts':
             ['pdf-table-extract=pdftableextract.scripts:main']


### PR DESCRIPTION
The current setup.py uses the _trick_ of parsing the requirements.txt. Although pip is very common, this is an extra requirement (implicitly) to install the package, saving just  `['numpy']`. This version work with pip (`pip install .`) but also without it (`python setup.py install`)

Moreover, pip < 1.2 had an [ugly bug](https://github.com/pypa/pip/pull/1027?source=cc) in the `parse_requirements` function, which increases the dependency pain. 
