### PR TITLE
Adding exceptions to subprocess calls.

### DIFF
--- a/src/pdftableextract/pnm.py
+++ b/src/pdftableextract/pnm.py
@@ -18,7 +18,10 @@ def readPNM(fd):
   s = noncomment(fd)
   m = noncomment(fd) if not (t.startswith('P1') or t.startswith('P4')) else '1'
   data = fd.read()
-
+  ls = len(s.split())
+  if ls != 2 :
+    name = "<pipe>" if fd.name=="<fdopen>" else "Filename = {0}".format(fd.name)
+    raise IOError("Expected 2 elements from parsing PNM file, got {0}: {1}".format(ls, name))
   xs, ys = s.split()
   width = int(xs)
   height = int(ys)

--- a/src/pdftableextract/scripts.py
+++ b/src/pdftableextract/scripts.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import logging
+import subprocess
 from .core import process_page, output
 #-----------------------------------------------------------------------
 
@@ -56,6 +57,18 @@ def procargs() :
   return p.parse_args()
 
 def main():
+  try:
+    imain()
+  except IOError as e:
+    sys.exit("I/O Error running pdf-table-extract: {0}".format(e))
+  except OSError as e:
+    sys.exit("OS Error: {0}".format(e))
+  except subprocess.CalledProcessError as e:
+    sys.exit("Error while checking a subprocess call: {0}".format(e))
+  except Exception as e:
+    sys.exit(e)
+
+def imain():
     import core
     args = procargs()
     cells = []

--- a/src/pdftableextract/scripts.py
+++ b/src/pdftableextract/scripts.py
@@ -62,6 +62,7 @@ def main():
   except IOError as e:
     sys.exit("I/O Error running pdf-table-extract: {0}".format(e))
   except OSError as e:
+    print("An OS Error occurred running pdf-table-extract: Is `pdftoppm` installed and available?")
     sys.exit("OS Error: {0}".format(e))
   except subprocess.CalledProcessError as e:
     sys.exit("Error while checking a subprocess call: {0}".format(e))


### PR DESCRIPTION
1. Before use, a subprocess.check_call is used to check if
   pdftoppm exists and is callable. Exceptions are raised for missing executable and non-zero return codes.
2. Exceptions are checked after each subprocess.popen, not that they catch much.
3. Exceptions in the PNM parsing are raised if the number of parameters in the line
   is incorrect (usually because the pdf is empty).
