### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/ASHIMA.md
+++ b/ASHIMA.md
@@ -7,10 +7,10 @@ in tables from a PDF file, and was originally designed to read the
 tables in ST Micro’s datasheets. The script requires numpy and poppler
 (pdftoppm and pdftotext)
 
-###License
+### License
 [MIT Expat](http://ashimagroup.net/os/license/mit-expat)
 
-###Tags
+### Tags
 [Utilities](http://ashimagroup.net/os/tag/utilities)
 
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ in tables from a PDF file, and was originally designed to read the
 tables in ST Micro’s datasheets. The script requires numpy and poppler
 (pdftoppm and pdftotext)
 
-###License
+### License
 [MIT Expat](http://ashimagroup.net/os/license/mit-expat)
 
-###Tags
+### Tags
 [Utilities](http://ashimagroup.net/os/tag/utilities)
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
